### PR TITLE
CF-USB-sidecar 1.0.1: Fix incorrect docker registry

### DIFF
--- a/stable/cf-usb-sidecar-mysql/values.yaml
+++ b/stable/cf-usb-sidecar-mysql/values.yaml
@@ -18,7 +18,7 @@ kube:
     persistent: "persistent"
     shared: "shared"
   registry:
-    hostname: registry.suse.de
+    hostname: registry.suse.com
     username: ""
     password: ""
   organization: cap

--- a/stable/cf-usb-sidecar-postgres/values.yaml
+++ b/stable/cf-usb-sidecar-postgres/values.yaml
@@ -20,7 +20,7 @@ kube:
     persistent: persistent
     shared: shared
   registry:
-    hostname: registry.suse.de
+    hostname: registry.suse.com
     username: ""
     password: ""
   organization: cap


### PR DESCRIPTION
The public registry is at `registry.suse.com`; `registry.suse.de` doesn't work.