### PR TITLE
stable/cf/Chart.yaml: Fix CF (CAP) appVersion

### DIFF
--- a/stable/cf/Chart.yaml
+++ b/stable/cf/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: 2.15.2+cf3.6.0.0.gde1bd02f
-appVersion: 1.13.1
+appVersion: 1.3.1
 description: A Helm chart for SUSE Cloud Foundry
 name: cf
 version: 2.15.2


### PR DESCRIPTION
A typo made in the sources made this 1.13.1 instead of 1.3.1