### PR TITLE
nginx-ingress: Fix defaut-backend image data

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.28.3
+version: 0.28.4
 appVersion: 0.15.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -291,8 +291,8 @@ defaultBackend:
 
   name: default-backend
   image:
-    repository: k8s.gcr.io/defaultbackend
-    tag: "1.4"
+    repository: registry.suse.com/sles12/default-http-backend
+    tag: "0.15.0"
     pullPolicy: IfNotPresent
 
   extraArgs: {}


### PR DESCRIPTION
Before this change, default-backend was using the upstream image instead
of SUSE image.

Fixes: bsc#1125400