### PR TITLE
Fix incompatible RFC5424 message format

### DIFF
--- a/stable/log-agent-rsyslog/Chart.yaml
+++ b/stable/log-agent-rsyslog/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 8.39.0
 description: Log Agent for forwarding logs of K8s control plane, namespaces, operating system to Rsyslog
 name: log-agent-rsyslog
-version: 1.0.0
+version: 1.0.1

--- a/stable/log-agent-rsyslog/templates/configmap.yaml
+++ b/stable/log-agent-rsyslog/templates/configmap.yaml
@@ -532,19 +532,19 @@ data:
     template(name="k8s_sd" type="list") {
         constant(value="[")
           property(name="$!custom_k8s_sd_id")
-          constant(value=" namespace_id=") property(name="$!kubernetes!namespace_id")
-          constant(value=" container_name=") property(name="$!kubernetes!container_name")
-          constant(value=" creation_timestamp=") property(name="$!kubernetes!creation_timestamp")
-          constant(value=" host=") property(name="$!kubernetes!host")
-          constant(value=" namespace_name=") property(name="$!kubernetes!namespace_name")
-          constant(value=" master_url=") property(name="$!kubernetes!master_url")
-          constant(value=" pod_id=") property(name="$!kubernetes!pod_id")
-          constant(value=" pod_name=") property(name="$!kubernetes!pod_name")
+          constant(value=" namespace_id=\"") property(name="$!kubernetes!namespace_id") constant(value="\"")
+          constant(value=" container_name=\"") property(name="$!kubernetes!container_name") constant(value="\"")
+          constant(value=" creation_timestamp=\"") property(name="$!kubernetes!creation_timestamp") constant(value="\"")
+          constant(value=" host=\"") property(name="$!kubernetes!host") constant(value="\"")
+          constant(value=" namespace_name=\"") property(name="$!kubernetes!namespace_name") constant(value="\"")
+          constant(value=" master_url=\"") property(name="$!kubernetes!master_url") constant(value="\"")
+          constant(value=" pod_id=\"") property(name="$!kubernetes!pod_id") constant(value="\"")
+          constant(value=" pod_name=\"") property(name="$!kubernetes!pod_name") constant(value="\"")
           {{- if ( eq .Values.kubernetesPodLabelsEnabled true ) }}
-          constant(value=" labels=") property(name="$!kubernetes!labels")
+          constant(value=" labels=\"") property(name="$!kubernetes!labels" format="json") constant(value="\"")
           {{- end }}
           {{- if ( eq .Values.kubernetesPodAnnotationsEnabled true ) }}
-          constant(value=" annotations=") property(name="$!kubernetes!annotations")
+          constant(value=" annotations=\"") property(name="$!kubernetes!annotations" format="json") constant(value="\"")
           {{- end }}
         constant(value="]")
     }


### PR DESCRIPTION
1. Adding double quote in keys and values of RFC5424 structured data for qualified RFC5424 message format, compatible with other Syslog solutions like syslog-ng.
2. Update version to 1.0.1

Ref: https://github.com/SUSE/avant-garde/issues/476

cc @cclhsu @c3y1huang @jhsiaosuse @jordimassaguerpla @lcavajani