### PR TITLE
Deprecated APIs removed in kubernetes 1.16

### DIFF
--- a/stable/cf-usb-sidecar-mysql/templates/sidecar.yaml
+++ b/stable/cf-usb-sidecar-mysql/templates/sidecar.yaml
@@ -1,7 +1,7 @@
 ---
 # The sidecar role for cf-usb-sidecar-mysql contains the main
 # deployment of the sidecar (csm + extension binaries).
-apiVersion: "extensions/v1beta1"
+apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "cf-usb-sidecar-mysql"

--- a/stable/cf-usb-sidecar-postgres/templates/sidecar.yaml
+++ b/stable/cf-usb-sidecar-postgres/templates/sidecar.yaml
@@ -1,7 +1,7 @@
 ---
 # The sidecar role for cf-usb-sidecar-postgres contains the main
 # deployment of the sidecar (csm + extension binaries).
-apiVersion: "extensions/v1beta1"
+apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: "cf-usb-sidecar-postgres"

--- a/stable/cf/templates/adapter.yaml
+++ b/stable/cf/templates/adapter.yaml
@@ -125,7 +125,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "adapter"

--- a/stable/cf/templates/api-group.yaml
+++ b/stable/cf/templates/api-group.yaml
@@ -164,7 +164,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "api-group"

--- a/stable/cf/templates/auth-psp-default.yaml
+++ b/stable/cf/templates/auth-psp-default.yaml
@@ -1,7 +1,7 @@
 ---
 # Pod security policy "default"
 {{- if and (eq (printf "%s" .Values.kube.auth) "rbac") (not .Values.kube.psp.default) }}
-apiVersion: "extensions/v1beta1"
+apiVersion: "policy/v1beta1"
 kind: "PodSecurityPolicy"
 metadata:
   name: {{ template "fissile.SanitizeName" (printf "%s-psp-default" .Release.Namespace) }}

--- a/stable/cf/templates/autoscaler-actors.yaml
+++ b/stable/cf/templates/autoscaler-actors.yaml
@@ -244,7 +244,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "autoscaler-actors"

--- a/stable/cf/templates/autoscaler-api.yaml
+++ b/stable/cf/templates/autoscaler-api.yaml
@@ -132,7 +132,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "autoscaler-api"

--- a/stable/cf/templates/autoscaler-metrics.yaml
+++ b/stable/cf/templates/autoscaler-metrics.yaml
@@ -193,7 +193,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "autoscaler-metrics"

--- a/stable/cf/templates/autoscaler-postgres.yaml
+++ b/stable/cf/templates/autoscaler-postgres.yaml
@@ -118,7 +118,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "autoscaler-postgres"

--- a/stable/cf/templates/bits.yaml
+++ b/stable/cf/templates/bits.yaml
@@ -117,7 +117,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "bits"

--- a/stable/cf/templates/blobstore.yaml
+++ b/stable/cf/templates/blobstore.yaml
@@ -127,7 +127,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "blobstore"

--- a/stable/cf/templates/cc-clock.yaml
+++ b/stable/cf/templates/cc-clock.yaml
@@ -47,7 +47,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "cc-clock"

--- a/stable/cf/templates/cc-uploader.yaml
+++ b/stable/cf/templates/cc-uploader.yaml
@@ -127,7 +127,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "cc-uploader"

--- a/stable/cf/templates/cc-worker.yaml
+++ b/stable/cf/templates/cc-worker.yaml
@@ -43,7 +43,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "cc-worker"

--- a/stable/cf/templates/cf-usb-group.yaml
+++ b/stable/cf/templates/cf-usb-group.yaml
@@ -132,7 +132,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "cf-usb-group"

--- a/stable/cf/templates/credhub-user.yaml
+++ b/stable/cf/templates/credhub-user.yaml
@@ -118,7 +118,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "credhub-user"

--- a/stable/cf/templates/diego-api.yaml
+++ b/stable/cf/templates/diego-api.yaml
@@ -136,7 +136,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "diego-api"

--- a/stable/cf/templates/diego-brain.yaml
+++ b/stable/cf/templates/diego-brain.yaml
@@ -124,7 +124,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "diego-brain"

--- a/stable/cf/templates/diego-cell.yaml
+++ b/stable/cf/templates/diego-cell.yaml
@@ -303,7 +303,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "diego-cell"

--- a/stable/cf/templates/diego-ssh.yaml
+++ b/stable/cf/templates/diego-ssh.yaml
@@ -204,7 +204,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "diego-ssh"

--- a/stable/cf/templates/doppler.yaml
+++ b/stable/cf/templates/doppler.yaml
@@ -229,7 +229,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "doppler"

--- a/stable/cf/templates/eirini.yaml
+++ b/stable/cf/templates/eirini.yaml
@@ -224,7 +224,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "eirini"

--- a/stable/cf/templates/locket.yaml
+++ b/stable/cf/templates/locket.yaml
@@ -118,7 +118,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "locket"

--- a/stable/cf/templates/log-api.yaml
+++ b/stable/cf/templates/log-api.yaml
@@ -220,7 +220,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "log-api"

--- a/stable/cf/templates/log-cache-scheduler.yaml
+++ b/stable/cf/templates/log-cache-scheduler.yaml
@@ -43,7 +43,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "log-cache-scheduler"

--- a/stable/cf/templates/mysql-proxy.yaml
+++ b/stable/cf/templates/mysql-proxy.yaml
@@ -137,7 +137,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "mysql-proxy"

--- a/stable/cf/templates/mysql.yaml
+++ b/stable/cf/templates/mysql.yaml
@@ -145,7 +145,7 @@ _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "
 _oddReplicas: {{ fail "mysql must have an odd instance count" }}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "mysql"

--- a/stable/cf/templates/nats.yaml
+++ b/stable/cf/templates/nats.yaml
@@ -128,7 +128,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "nats"

--- a/stable/cf/templates/nfs-broker.yaml
+++ b/stable/cf/templates/nfs-broker.yaml
@@ -118,7 +118,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "nfs-broker"

--- a/stable/cf/templates/router.yaml
+++ b/stable/cf/templates/router.yaml
@@ -172,7 +172,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "router"

--- a/stable/cf/templates/routing-api.yaml
+++ b/stable/cf/templates/routing-api.yaml
@@ -118,7 +118,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "routing-api"

--- a/stable/cf/templates/syslog-scheduler.yaml
+++ b/stable/cf/templates/syslog-scheduler.yaml
@@ -113,7 +113,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "syslog-scheduler"

--- a/stable/cf/templates/tcp-router.yaml
+++ b/stable/cf/templates/tcp-router.yaml
@@ -172,7 +172,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "tcp-router"

--- a/stable/cf/templates/uaa.yaml
+++ b/stable/cf/templates/uaa.yaml
@@ -175,7 +175,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "uaa"

--- a/stable/console/templates/deployment.yaml
+++ b/stable/console/templates/deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: stratos
@@ -309,7 +309,7 @@ spec:
           name: {{ .Values.console.templatesConfigMapName }}
       {{- end }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: stratos-db

--- a/stable/log-agent-rsyslog/tests/helpers/rsyslog-server/rsyslog-server-deployment.yaml
+++ b/stable/log-agent-rsyslog/tests/helpers/rsyslog-server/rsyslog-server-deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rsyslog-server

--- a/stable/metrics/charts/prometheus/templates/alertmanager-deployment.yaml
+++ b/stable/metrics/charts/prometheus/templates/alertmanager-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.alertmanager.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/stable/metrics/charts/prometheus/templates/kube-state-metrics-deployment.yaml
+++ b/stable/metrics/charts/prometheus/templates/kube-state-metrics-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.kubeStateMetrics.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
 {{- if .Values.kubeStateMetrics.deploymentAnnotations }}

--- a/stable/metrics/charts/prometheus/templates/node-exporter-daemonset.yaml
+++ b/stable/metrics/charts/prometheus/templates/node-exporter-daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.nodeExporter.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
 {{- if .Values.nodeExporter.deploymentAnnotations }}

--- a/stable/metrics/charts/prometheus/templates/node-exporter-podsecuritypolicy.yaml
+++ b/stable/metrics/charts/prometheus/templates/node-exporter-podsecuritypolicy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create }}
 {{- if .Values.nodeExporter.podSecurityPolicy.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus.nodeExporter.fullname" . }}

--- a/stable/metrics/charts/prometheus/templates/pushgateway-deployment.yaml
+++ b/stable/metrics/charts/prometheus/templates/pushgateway-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.pushgateway.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/stable/metrics/charts/prometheus/templates/server-deployment.yaml
+++ b/stable/metrics/charts/prometheus/templates/server-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
 {{- if .Values.server.deploymentAnnotations }}

--- a/stable/metrics/templates/cf-exporter.yaml
+++ b/stable/metrics/templates/cf-exporter.yaml
@@ -2,7 +2,7 @@
 {{- if .Values.cfExporter.enabled }}
 {{ $cfExporterClientSecret :=  default (randAlphaNum 64) .Values.cfExporter.uaa.clientSecret }}
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ .Release.Name }}-cf-exporter"

--- a/stable/metrics/templates/deployment.yaml
+++ b/stable/metrics/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{ $firehoseClientSecret :=  default (randAlphaNum 64) .Values.firehoseExporter.uaa.clientSecret }}
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ .Release.Name }}-nginx"
@@ -118,7 +118,7 @@ spec:
   {{- range int .Values.firehoseExporter.instances | until }}
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ $releaseName }}-firehose-exporters-{{ . }}"

--- a/stable/uaa/templates/auth-psp-default.yaml
+++ b/stable/uaa/templates/auth-psp-default.yaml
@@ -1,7 +1,7 @@
 ---
 # Pod security policy "default"
 {{- if and (eq (printf "%s" .Values.kube.auth) "rbac") (not .Values.kube.psp.default) }}
-apiVersion: "extensions/v1beta1"
+apiVersion: "policy/v1beta1"
 kind: "PodSecurityPolicy"
 metadata:
   name: {{ template "fissile.SanitizeName" (printf "%s-psp-default" .Release.Namespace) }}

--- a/stable/uaa/templates/mysql-proxy.yaml
+++ b/stable/uaa/templates/mysql-proxy.yaml
@@ -137,7 +137,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "mysql-proxy"

--- a/stable/uaa/templates/mysql.yaml
+++ b/stable/uaa/templates/mysql.yaml
@@ -141,7 +141,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "mysql"

--- a/stable/uaa/templates/uaa.yaml
+++ b/stable/uaa/templates/uaa.yaml
@@ -172,7 +172,7 @@ _moved_sizing_memory_limits: {{ if .Values.sizing.memory.limits }} {{ fail "Bad 
 _moved_sizing_memory_requests: {{ if .Values.sizing.memory.requests }} {{ fail "Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests" }} {{else}} ok {{end}}
 {{- end }}
 
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: "StatefulSet"
 metadata:
   name: "uaa"


### PR DESCRIPTION
Ref: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

PodSecurityPolicy: from `extensions/v1beta1` to `policy/v1beta1`
DaemonSet: from `extensions/v1beta1` to `apps/v1`
Deployment: from `extensions/v1beta1` or `apps/v1beta1` to `apps/v1`
StatefulSet: from `apps/v1beta1` -> `apps/v1`

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>