### PR TITLE
Fix default name of stratos' ingress tls

### DIFF
--- a/stable/console/templates/ingress.yaml
+++ b/stable/console/templates/ingress.yaml
@@ -60,7 +60,7 @@ metadata:
 {{- end }}    
 spec:
   tls:
-  - secretName: {{ default "{{ .Release.Name }}-ingress-tls" .Values.console.service.ingress.secretName | quote }}
+  - secretName: {{ .Values.console.service.ingress.secretName | default (print .Release.Name "-ingress-tls") | quote }}
     hosts:
     - {{ template "ingress.host" . }}
   rules:


### PR DESCRIPTION
This commit fixes the templating used to generate the default name of the TLS secret referenced by the stratos ingress.

Without the patch the helm templating is not expanded, resulting in the Ingress controller trying to find a secret named "{{ .Release.Name }}-ingress-tls".

Note well: this happens with helm v2. I haven't tried with v3.