### PR TITLE
Fix rsyslog container log format

### DIFF
--- a/stable/log-agent-rsyslog/Chart.yaml
+++ b/stable/log-agent-rsyslog/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 8.39.0
 description: Log Agent for forwarding logs of K8s control plane, namespaces, operating system to Rsyslog
 name: log-agent-rsyslog
-version: 1.0.1
+version: 1.0.2

--- a/stable/log-agent-rsyslog/templates/configmap.yaml
+++ b/stable/log-agent-rsyslog/templates/configmap.yaml
@@ -524,9 +524,9 @@ data:
         constant(value="k8s.pod/")
         property(name="!kubernetes!namespace_name")
         constant(value="/")
-        property(name="!kubernetes!pod_name")
-        constant(value="/")
         property(name="!kubernetes!container_name")
+        constant(value="/")
+        property(name="!kubernetes!pod_name")
     }
 
     template(name="k8s_sd" type="list") {


### PR DESCRIPTION
The mmkubernetes seems to interpret `pod_name` and `container_name`
differently. Swap around to get to expected format name.

### Before
k8s.pod/default/`demo-log-agent-rsyslog-5rrjh`/`log-agent-rsyslog` 
```
<133>1 2019-12-18T08:10:24.281041+00:00 caasp-master-c3y1-cluster-0 k8s.pod/default/demo-log-agent-rsyslog-5rrjh/log-agent-rsyslog - - [kube_meta namespace_id="e17e6829-0d8d-443b-85a9-7d538947112b" container_name="log-agent-rsyslog" creation_timestamp="2019-12-18T07:34:43Z" host="caasp-master-c3y1-cluster-0" namespace_name="default" master_url="https://kubernetes.default.svc.cluster.local:443" pod_id="a45a8cb5-6618-482b-b12a-073b51e14093" pod_name="demo-log-agent-rsyslog-5rrjh"] 2019-12-18T08:10:24.130493306+00:00 stderr P Stack now 0 1 6 32 63 102 139
```
 
### After
k8s.pod/default/`log-agent-rsyslog`/`demo-log-agent-rsyslog-dfdks`
```
<133>1 2019-12-18T08:12:04.007076+00:00 caasp-worker-c3y1-cluster-2 k8s.pod/default/log-agent-rsyslog/demo-log-agent-rsyslog-dfdks - - [kube_meta namespace_id="e17e6829-0d8d-443b-85a9-7d538947112b" container_name="log-agent-rsyslog" creation_timestamp="2019-12-18T07:34:43Z" host="caasp-worker-c3y1-cluster-2" namespace_name="default" master_url="https://kubernetes.default.svc.cluster.local:443" pod_id="6293d3e4-fc55-453d-8b71-ffad6a158b67" pod_name="demo-log-agent-rsyslog-dfdks"] 2019-12-18T08:12:03.871634609+00:00 stderr F )
```

Fix: https://github.com/SUSE/caasp-test-cases/pull/8#discussion_r358023634
Ref: https://github.com/SUSE/avant-garde/issues/1179

Signed-off-by: Chin-Ya Huang <chin-ya.huang@suse.com>