### PR TITLE
Migrate deprecated API in nginx-ingress chart

### DIFF
--- a/stable/nginx-ingress/templates/podsecuritypolicy.yaml
+++ b/stable/nginx-ingress/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podSecurityPolicy.enabled}}
-apiVersion: extensions
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "nginx-ingress.fullname" . }} 


### PR DESCRIPTION
ref: https://github.com/SUSE/doc-caasp/issues/676

We have a bug in our nginx-ingress helm chart, we forgot to migrate the deprecated API from `apiVersion: extensions` to `apiVersion: policy/v1beta1` according to https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

Then the helm chart can be deployed (from git) with enabled PSP:
```
helm install --name nginx-ingress --namespace nginx-ingress ./nginx-ingress --values ./nginx-ingress-config-values.yaml
```
Used nginx-ingress-config-values.yaml:
```
# Enable the creation of pod security policy
podSecurityPolicy:
  enabled: true

# Create a specific service account
serviceAccount:
  create: true
  name: nginx-ingress

# Publish services on port HTTPS/30443
# These services are exposed on each node
controller:
  service:
    enableHttp: true
    enableHttps: true
    type: NodePort
    nodePorts:
      http: 30080
      https: 30443
```



After the change it works as expected with CaaSP 4.1.0. The API is available since k8s v1.10 so it should work with CaaSP 3 as well (based on k8s v1.13).