### PR TITLE
WIP: Use kube-state-metrics:1.9.3 in prometheus

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 9.3.2
+version: 9.3.3
 appVersion: 2.13.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -323,7 +323,7 @@ kubeStateMetrics:
   ##
   image:
     repository: registry.suse.com/caasp/v4/kube-state-metrics
-    tag: "1.6.0"
+    tag: "1.9.3"
     pullPolicy: IfNotPresent
 
   ## kube-state-metrics priorityClassName


### PR DESCRIPTION
This is version bump for using latest image kube-state-metrics:1.9.3 in prometheus needed for https://github.com/SUSE/avant-garde/issues/1267

The image is not released yet so hence marking WIP until the new image will be release.