### PR TITLE
Fix bsc#1161225

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: grafana
 version: 4.0.0
-appVersion: 6.4.2
+appVersion: 6.2.5
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: prometheus
 version: 9.3.3
-appVersion: 2.13.1
+appVersion: 2.7.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png


### PR DESCRIPTION
Correct the SUSE CaaS team release package version
- registry.suse.com/caasp/v4/prometheus: `2.7.1`
- registry.suse.com/caasp/v4/grafana: `6.2.5`

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>