### PR TITLE
Update NOTES.txt

### DIFF
--- a/stable/grafana/templates/NOTES.txt
+++ b/stable/grafana/templates/NOTES.txt
@@ -8,7 +8,7 @@
 {{ if .Values.ingress.enabled }}
    From outside the cluster, the server URL(s) are:
 {{- range .Values.ingress.hosts }}
-     http://{{ . }}
+     https://{{ . }}
 {{- end }}
 {{ else }}
    Get the Grafana URL to visit by running these commands in the same shell:


### PR DESCRIPTION
I was not aware that we have SUSE Helm Chart on Github. The output should be https:// not http:// ; we have this written correct in our Doc.