### PR TITLE
Release Metrics 1.2.1

### DIFF
--- a/stable/metrics/Chart.yaml
+++ b/stable/metrics/Chart.yaml
@@ -5,4 +5,4 @@ icon: https://raw.githubusercontent.com/SUSE/stratos-metrics/master/icon.svg
 name: metrics
 sources:
 - https://github.com/SUSE/stratos-metrics
-version: 1.2.0
+version: 1.2.1

--- a/stable/metrics/requirements.lock
+++ b/stable/metrics/requirements.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 10.3.0
 digest: sha256:805e4b79f55f59a0db2216d56e7848debb88c6d1d2384ab25ef17514669952a5
-generated: 2020-01-16T11:58:09.348788Z
+generated: "2020-05-18T10:51:05.855902658+01:00"

--- a/stable/metrics/templates/_helpers.tpl
+++ b/stable/metrics/templates/_helpers.tpl
@@ -253,3 +253,14 @@ Ingress Host:
 {{ required "Host name is required" $host | quote }}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Generate self-signed certificate for Metrics if needed
+*/}}
+{{- define "metrics.generateCertificate" -}}
+{{- $altNames := list (printf "%s.%s" (include "metrics.certName" .) .Release.Namespace ) ( printf "%s.%s.svc" (include "metrics.certName" .) .Release.Namespace ) -}}
+{{- $ca := genCA "stratos-ca" 365 -}}
+{{- $cert := genSignedCert ( include "metrics.certName" . ) nil $altNames 365 $ca }}  cert.crt: {{ $cert.Cert | b64enc | quote }}
+  cert.key: {{ $cert.Key | b64enc | quote }}
+{{- end -}}

--- a/stable/metrics/templates/secrets.yaml
+++ b/stable/metrics/templates/secrets.yaml
@@ -13,7 +13,7 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 data:
   .dockercfg: {{ template "imagePullSecret" . }}
-{{- end}}
+{{- end }}
 {{- if not .Values.nginx.tls }}
 ---
 apiVersion: v1
@@ -22,9 +22,13 @@ metadata:
   name: "{{ .Release.Name }}-nginx-tls"
 type: Opaque
 data:
+{{- if and .Values.nginx.ssl.cert .Values.nginx.ssl.certKey }}
   cert.crt: {{ .Values.nginx.ssl.cert | b64enc }}
   cert.key: {{ .Values.nginx.ssl.certKey | b64enc }}
-{{- end}}
+{{- else }}
+{{ template "metrics.generateCertificate" . }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Secret
@@ -34,3 +38,4 @@ type: Opaque
 data:
   username: {{ template "nginx.credentials-username-base64" . }}
   password: {{ template "nginx.credentials-password-base64" . }}
+

--- a/stable/metrics/values.yaml
+++ b/stable/metrics/values.yaml
@@ -1,6 +1,6 @@
 # Default values for stratos-metrics
 dockerRepository: registry.suse.com
-dockerOrganization: cap-staging
+dockerOrganization: cap
 dockerRegistrySecret: regsecret
 imageTag: 1.2.0-bc511c9-cap
 imagePullPolicy: IfNotPresent
@@ -87,59 +87,11 @@ nginx:
   image: stratos-metrics-nginx
   # Name of secret to use for TLS rather than a self-signed certificate
   tls:
+  # Alternative to secret name is supplying cert and key directly here
   ssl:
-    cert: |
-      -----BEGIN CERTIFICATE-----
-      MIIDXTCCAkWgAwIBAgIJAJooOiQWl1v1MA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
-      BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX
-      aWRnaXRzIFB0eSBMdGQwHhcNMTcwNjIzMTQ1MDM5WhcNMTgwNjIzMTQ1MDM5WjBF
-      MQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50
-      ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
-      CgKCAQEA1ffskodMWczONUmpW35pNXFsFD/UGEvzCsXHme64f62JaEWYiK/WoDhy
-      gjUnRU0m/UU03+5nBRj3T10ONrjq85Vbvz3itR5b9rRH+8xQTJstHRFgdz5B9pLx
-      43GExyBwuAqcu7fSkZUQkN8gBjyxcwrKYM9So/IBLtf7Rhejg6/qr3WNnfAVUQhK
-      qywBXnxCgA4kIRJKxbQY83XPBXIBcdRH5xsBDX0d9Tsre/v9G/BaiU//CvhpVzEJ
-      iTzRDjca2C/v8Q7MxcPwInAFM9Vz+iKsu6+grDFoiNh3hql+meET1nmSE7q+dIOA
-      Z58Enk5BYsOxJN/fmyuesIL0S3CKSwIDAQABo1AwTjAdBgNVHQ4EFgQUXucATEFh
-      8s94Mg1+J/aP8potwhMwHwYDVR0jBBgwFoAUXucATEFh8s94Mg1+J/aP8potwhMw
-      DAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAGroqi6rKMjw3mCtr6dAU
-      WgGXiO96ADRzRchdp+gpHTVtybKAa1n13MAs/tl7HKUBQWwvDqPlqAAmBtCDKhfh
-      N8SiI8PxScaCE2NcJCJDHwxs2CucUSAIf99w+WIZ0pF2IC+73GTCR+p9Kwb5bN04
-      8vN/7YQTMwNk7GxkKas9QPR9/6rvPHLGPYvPx8mOW6HbYaWdPavJAI/XAYPxnfid
-      uQuNfXXbhJyxN1BUi1Kt+KkVCyG+CY0jJNbO7lTsiJSzcstLykSxTX1bw0jIvEWa
-      LdXmd/Dyu/EVzgOYnEPiZmHbha4KuVsb0dtAQIT8hmVRXIIOIbndERBduxeVMkLm
-      fw==
-      -----END CERTIFICATE-----
-    certKey: |
-      -----BEGIN PRIVATE KEY-----
-      MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDV9+ySh0xZzM41
-      Salbfmk1cWwUP9QYS/MKxceZ7rh/rYloRZiIr9agOHKCNSdFTSb9RTTf7mcFGPdP
-      XQ42uOrzlVu/PeK1Hlv2tEf7zFBMmy0dEWB3PkH2kvHjcYTHIHC4Cpy7t9KRlRCQ
-      3yAGPLFzCspgz1Kj8gEu1/tGF6ODr+qvdY2d8BVRCEqrLAFefEKADiQhEkrFtBjz
-      dc8FcgFx1EfnGwENfR31Oyt7+/0b8FqJT/8K+GlXMQmJPNEONxrYL+/xDszFw/Ai
-      cAUz1XP6Iqy7r6CsMWiI2HeGqX6Z4RPWeZITur50g4BnnwSeTkFiw7Ek39+bK56w
-      gvRLcIpLAgMBAAECggEBANNJuycGy/JxN7+POdnLfoDzu9JTJVHIzft5Sp1LCo2q
-      A+Ift3xihwI4O3swmdLpWPMJACmQ9dIm0TBhp8OJ3xkiCDNVHSXVEOMRK3QOUc0T
-      /vyRSDz4EZM3j/0VABTSh/x1HkiQQTLZjD5C1xDRpjkAEtB+ahDSzTBAvzR761AA
-      +y3fQz59jUwEoC1fOmzd333brgUGG3rwaqdg5qyXQBQH3k2RC10r9GXoc5fvkwO7
-      M2n2rW3WdytT3Yhb+Cvv+EZsJVs6lX8dyQcdfFLP9ivBjzRbNTxm6sA1vnmq0xf4
-      7ixC8MJk/N9ZRRGTcohxS97AfsnFqwqOTeGPrsdqFqECgYEA/5IHgr8ubnmTJ0ep
-      0+n69jqVQkfMJ0/sPlXP/+1yywYxkf6kSm8JXboa1W+j3vsRMRYUWAQVLp8ALrLk
-      x3aQG024CayryabcdFPrfdbdQV1Ik+8RYae34uKiOgyOJVyy96YuqM4QCvqY5GYp
-      u+rthafJq4kGAzU6Pli7yI3ZsM8CgYEA1lP+YBHotCR993jXGa0OIwmqI7+n9EWV
-      k/ubNxutEqXE+VL4hXrWWn9mLD4MJ9y+umppTdzEawUcM9MoVD7eeQUwkgMiDlUd
-      2c62pHHStYyKHaY85Zp1yovFDDjtROErXT9+fXcDAxSP0MOapEC9tToY1seVfJLH
-      pj/U52ONlcUCgYEAnCUzU43NJ5A9+QzO1Puq6k/Gq9VEBWzOUROK3rnLngFtvd5P
-      sG6A0XQIOwlXnL/WtB/iVBhCfNaGfQGtx7RHvXbRj4+g8bZyENzJD3x8eBgvZLr2
-      6qxXLFb9eOv82RT2/1nYPiiQIrUTPtCwhPC3KCboj1ZLhyA5MqhyKsmIDH8CgYAb
-      nV7dCfGtpDYGuK8eQ8nagdhGGt+M/Zo0IurwwsQd7vXeGe6jZBxSNK/5a1UtnaeF
-      ZUiEG7nDADmOA9riX+dSOHT1mym8JwNdmOC3d2LquVziTRTzkF805aVR2dPYWBq6
-      PQATMk5VC0UsZMd7+kt3GjExGy4Liu3mYbsQxSbs8QKBgDPoTR3a39cjp4KgMS4z
-      9nRT5DV72/GE5N7EDrDHrhpUyW0qkM4UcJ5Vi+c4EywzOgtYbFknSsXbYnVAkFDr
-      42qv5Z0qoLTOch+GVuj0ZF1UgJh+RJWom7lPhTS0UP+VZFBc++nGl7PGTRflm3Zd
-      mEVvEQxyBz3V1fZ0Yz246W60
-      -----END PRIVATE KEY-----
-      
+    cert:
+    certKey:
+
  # SCF values compatability 
 env:
   # If DOMAIN is set, the CF API Endpoint will fallback to https://api.DOMAIN if not set
@@ -164,27 +116,27 @@ prometheus:
     enabled: false
   configmapReload:
     image:
-      repository: registry.suse.com/cap-staging/stratos-metrics-configmap-reload
+      repository: registry.suse.com/cap/stratos-metrics-configmap-reload
       tag: 1.2.0-bc511c9-cap
   initChownData:
     image:
-      repository: registry.suse.com/cap-staging/stratos-metrics-init-chown-data
+      repository: registry.suse.com/cap/stratos-metrics-init-chown-data
       tag: 1.2.0-bc511c9-cap
   kubeStateMetrics:
     enabled: false
     image:
-      repository: registry.suse.com/cap-staging/stratos-metrics-kube-state-metrics
+      repository: registry.suse.com/cap/stratos-metrics-kube-state-metrics
       tag: 1.2.0-bc511c9-cap
   nodeExporter:    
     enabled: false
     image:
-      repository: registry.suse.com/cap-staging/stratos-metrics-node-exporter
+      repository: registry.suse.com/cap/stratos-metrics-node-exporter
       tag: 1.2.0-bc511c9-cap
   server:
     name: prometheus
     configMapOverrideName: stratos-metrics-config
     image:
-      repository: registry.suse.com/cap-staging/stratos-metrics-prometheus
+      repository: registry.suse.com/cap/stratos-metrics-prometheus
       tag: 1.2.0-bc511c9-cap
     replicaCount: 1
     service:


### PR DESCRIPTION
- Fixes issue where an old, hard-coded self-signed cert was being used - one is generated now
- Fixes issue where image references were to cap-staging and not cap