### PR TITLE
Removed v from version value

### DIFF
--- a/stable/kubecf/Chart.yaml
+++ b/stable/kubecf/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 2.0.0-rc3
 description: A Helm chart for KubeCF
 icon: https://raw.githubusercontent.com/cloudfoundry-incubator/kubecf/master/icon/kubecf.png
 name: kubecf
-version: v2.2.2
+version: 2.2.2


### PR DESCRIPTION
`2.2.2` is proper semver whilst `v2.2.2` isn't.  

https://github.com/cloudfoundry-incubator/kubecf/issues/927 has been filed to address this in the pipeline.