### PR TITLE
Add reloader helm chart

### DIFF
--- a/stable/reloader/Chart.yaml
+++ b/stable/reloader/Chart.yaml
@@ -3,8 +3,8 @@
 apiVersion: v1
 name: reloader
 description: Reloader chart that runs on kubernetes
-version: v0.0.58
-appVersion: v0.0.58
+version: 0.0.58
+appVersion: 0.0.58
 keywords:
   - Reloader
   - kubernetes

--- a/stable/reloader/Chart.yaml
+++ b/stable/reloader/Chart.yaml
@@ -1,0 +1,29 @@
+# Generated from deployments/kubernetes/templates/chart/Chart.yaml.tmpl
+
+apiVersion: v1
+name: reloader
+description: Reloader chart that runs on kubernetes
+version: v0.0.58
+appVersion: v0.0.58
+keywords:
+  - Reloader
+  - kubernetes
+home: https://github.com/stakater/Reloader
+sources:
+- https://github.com/stakater/IngressMonitorController
+icon: https://raw.githubusercontent.com/stakater/Reloader/master/assets/web/reloader-round-100px.png
+maintainers:
+- name: Stakater
+  email: hello@stakater.com
+- name: rasheedamir
+  email: rasheed@aurorasolutions.io
+- name: waseem-h
+  email: waseemhassan@stakater.com
+- name: faizanahmad055
+  email: faizan.ahmad55@outlook.com
+- name: kahootali
+  email: ali.kahoot@aurorasolutions.io
+- name: ahmadiq
+  email: ahmad@aurorasolutions.io
+- name: ahsan-storm
+  email: ahsanmuhammad1@outlook.com

--- a/stable/reloader/OWNERS
+++ b/stable/reloader/OWNERS
@@ -1,0 +1,14 @@
+approvers:
+- faizanahmad055
+- kahootali
+- ahmadiq
+- waseem-h
+- rasheedamir
+- ahsan-storm
+reviewers:
+- faizanahmad055
+- kahootali
+- ahmadiq
+- waseem-h
+- rasheedamir
+- ahsan-storm

--- a/stable/reloader/templates/NOTES.txt
+++ b/stable/reloader/templates/NOTES.txt
@@ -1,0 +1,7 @@
+- For a `Deployment` called `foo` have a `ConfigMap` called `foo-configmap`. Then add this annotation to main metadata of your `Deployment`
+  configmap.reloader.stakater.com/reload: "foo-configmap"
+
+- For a `Deployment` called `foo` have a `Secret` called `foo-secret`. Then add this annotation to main metadata of  your `Deployment`
+  secret.reloader.stakater.com/reload: "foo-secret"
+
+- After successful installation, your pods will get rolling updates when a change in data of configmap or secret will happen.

--- a/stable/reloader/templates/_helpers.tpl
+++ b/stable/reloader/templates/_helpers.tpl
@@ -1,0 +1,35 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+
+{{- define "reloader-name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | lower -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "reloader-fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "reloader-labels.chart" -}}
+app: {{ template "reloader-fullname" . }}
+chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+release: {{ .Release.Name | quote }}
+heritage: {{ .Release.Service | quote }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "reloader-serviceAccountName" -}}
+{{- if .Values.reloader.serviceAccount.create -}}
+    {{ default (include "reloader-fullname" .) .Values.reloader.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.reloader.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/reloader/templates/clusterrole.yaml
+++ b/stable/reloader/templates/clusterrole.yaml
@@ -1,0 +1,62 @@
+{{- if and .Values.reloader.watchGlobally (.Values.reloader.rbac.enabled) }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+{{ include "reloader-labels.chart" . | indent 4 }}
+{{- if .Values.reloader.rbac.labels }}
+{{ toYaml .Values.reloader.rbac.labels | indent 4 }}
+{{- end }}
+{{- if .Values.reloader.matchLabels }}
+{{ toYaml .Values.reloader.matchLabels | indent 4 }}
+{{- end }}
+  name: {{ template "reloader-fullname" . }}-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+{{- if .Values.reloader.ignoreSecrets }}{{- else }}
+      - secrets
+{{- end }}
+{{- if .Values.reloader.ignoreConfigMaps }}{{- else }}
+      - configmaps
+{{- end }}
+    verbs:
+      - list
+      - get
+      - watch
+{{- if or (.Capabilities.APIVersions.Has "apps.openshift.io/v1") (.Values.isOpenshift) }}
+  - apiGroups:
+      - "apps.openshift.io"
+      - ""
+    resources:
+      - deploymentconfigs
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+{{- end }}
+  - apiGroups:
+      - "apps"
+    resources:
+      - deployments
+      - daemonsets
+      - statefulsets
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - deployments
+      - daemonsets
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+{{- end }}

--- a/stable/reloader/templates/clusterrolebinding.yaml
+++ b/stable/reloader/templates/clusterrolebinding.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.reloader.watchGlobally (.Values.reloader.rbac.enabled) }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+{{ include "reloader-labels.chart" . | indent 4 }}
+{{- if .Values.reloader.rbac.labels }}
+{{ toYaml .Values.reloader.rbac.labels | indent 4 }}
+{{- end }}
+{{- if .Values.reloader.matchLabels }}
+{{ toYaml .Values.reloader.matchLabels | indent 4 }}
+{{- end }}
+  name: {{ template "reloader-fullname" . }}-role-binding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "reloader-fullname" . }}-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "reloader-serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/stable/reloader/templates/deployment.yaml
+++ b/stable/reloader/templates/deployment.yaml
@@ -1,0 +1,132 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+{{- if .Values.reloader.deployment.annotations }}
+  annotations:
+{{ toYaml .Values.reloader.deployment.annotations | indent 4 }}
+{{- end }}
+  labels:
+{{ include "reloader-labels.chart" . | indent 4 }}
+{{- if .Values.reloader.deployment.labels }}
+{{ toYaml .Values.reloader.deployment.labels | indent 4 }}
+{{- end }}
+{{- if .Values.reloader.matchLabels }}
+{{ toYaml .Values.reloader.matchLabels | indent 4 }}
+{{- end }}
+  name: {{ template "reloader-fullname" . }}
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: {{ template "reloader-fullname" . }}
+      release: {{ .Release.Name | quote }}
+{{- if .Values.reloader.matchLabels }}
+{{ toYaml .Values.reloader.matchLabels | indent 6 }}
+{{- end }}
+  template:
+    metadata:
+{{- if .Values.reloader.deployment.pod.annotations }}
+      annotations:
+{{ toYaml .Values.reloader.deployment.pod.annotations | indent 8 }}
+{{- end }}
+      labels:
+{{ include "reloader-labels.chart" . | indent 8 }}
+{{- if .Values.reloader.deployment.labels }}
+{{ toYaml .Values.reloader.deployment.labels | indent 8 }}
+{{- end }}
+{{- if .Values.reloader.matchLabels }}
+{{ toYaml .Values.reloader.matchLabels | indent 8 }}
+{{- end }}
+    spec:
+      {{- if .Values.reloader.deployment.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.reloader.deployment.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.reloader.deployment.affinity }}
+      affinity:
+{{ toYaml .Values.reloader.deployment.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.reloader.deployment.tolerations }}
+      tolerations:
+{{ toYaml .Values.reloader.deployment.tolerations | indent 8 }}
+      {{- end }}
+      containers:
+      - env:
+      {{- range $name, $value := .Values.reloader.deployment.env.open }}
+      {{- if not (empty $value) }}
+        - name: {{ $name | quote }}
+          value: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
+      {{- $secret_name := include "reloader-fullname" . }}
+      {{- range $name, $value := .Values.reloader.deployment.env.secret }}
+      {{- if not ( empty $value) }}
+        - name: {{ $name | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $secret_name }}
+              key: {{ $name | quote }}
+      {{- end }}
+      {{- end }}
+      {{- range $name, $value := .Values.reloader.deployment.env.field }}
+      {{- if not ( empty $value) }}
+        - name: {{ $name | quote }}
+          valueFrom:
+            fieldRef:
+              fieldPath: {{ $value | quote}}
+      {{- end }}
+      {{- end }}
+      {{- if eq .Values.reloader.watchGlobally false }}
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      {{- end }}
+        image: "{{ .Values.reloader.deployment.image.name }}:{{ .Values.reloader.deployment.image.tag }}"
+        imagePullPolicy: {{ .Values.reloader.deployment.image.pullPolicy }}
+        name: {{ template "reloader-fullname" . }}
+      {{- if eq .Values.reloader.readOnlyRootFileSystem true }}
+        volumeMounts:
+          - mountPath: /tmp/
+            name: tmp-volume
+      {{- end }}
+        args:
+          {{- if .Values.reloader.logFormat }}
+          - "--log-format={{ .Values.reloader.logFormat }}"
+          {{- end }}
+          {{- if .Values.reloader.ignoreSecrets }}
+          - "--resources-to-ignore=secrets"
+          {{- end }}
+          {{- if eq .Values.reloader.ignoreConfigMaps true }}
+          - "--resources-to-ignore=configMaps"
+          {{- end }}
+
+          {{- if .Values.reloader.custom_annotations }}
+            {{- if .Values.reloader.custom_annotations.configmap }}
+            - "--configmap-annotation"
+            - "{{ .Values.reloader.custom_annotations.configmap }}"
+            {{- end }}
+            {{- if .Values.reloader.custom_annotations.secret }}
+            - "--secret-annotation"
+            - "{{ .Values.reloader.custom_annotations.secret }}"
+            {{- end }}
+            {{- if .Values.reloader.custom_annotations.auto }}
+            - "--auto-annotation"
+            - "{{ .Values.reloader.custom_annotations.auto }}"
+            {{- end }}
+          {{- end }}
+
+      {{- if .Values.reloader.deployment.resources }}
+        resources:
+{{ toYaml .Values.reloader.deployment.resources | indent 10 }}
+      {{- end }}
+{{- if .Values.reloader.deployment.securityContext }}
+      securityContext: {{ toYaml .Values.reloader.deployment.securityContext | nindent 8 }}
+{{- end }}
+      serviceAccountName: {{ template "reloader-serviceAccountName" . }}
+    {{- if eq .Values.reloader.readOnlyRootFileSystem true }}
+      volumes:
+        - emptyDir: {}
+          name: tmp-volume
+    {{- end }}

--- a/stable/reloader/templates/role.yaml
+++ b/stable/reloader/templates/role.yaml
@@ -1,0 +1,62 @@
+{{- if and (not (.Values.reloader.watchGlobally)) (.Values.reloader.rbac.enabled) }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+{{ include "reloader-labels.chart" . | indent 4 }}
+{{- if .Values.reloader.rbac.labels }}
+{{ toYaml .Values.reloader.rbac.labels | indent 4 }}
+{{- end }}
+{{- if .Values.reloader.matchLabels }}
+{{ toYaml .Values.reloader.matchLabels | indent 4 }}
+{{- end }}
+  name: {{ template "reloader-fullname" . }}-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+{{- if .Values.reloader.ignoreSecrets }}{{- else }}
+      - secrets
+{{- end }}
+{{- if .Values.reloader.ignoreConfigMaps }}{{- else }}
+      - configmaps
+{{- end }}
+    verbs:
+      - list
+      - get
+      - watch
+{{- if or (.Capabilities.APIVersions.Has "apps.openshift.io/v1") (.Values.reloader.isOpenshift) }}
+  - apiGroups:
+      - "apps.openshift.io"
+      - ""
+    resources:
+      - deploymentconfigs
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+{{- end }}
+  - apiGroups:
+      - "apps"
+    resources:
+      - deployments
+      - daemonsets
+      - statefulsets
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - deployments
+      - daemonsets
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+{{- end }}

--- a/stable/reloader/templates/rolebinding.yaml
+++ b/stable/reloader/templates/rolebinding.yaml
@@ -1,0 +1,23 @@
+{{- if and (not (.Values.reloader.watchGlobally)) (.Values.reloader.rbac.enabled) }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels: 
+{{ include "reloader-labels.chart" . | indent 4 }}
+{{- if .Values.reloader.rbac.labels }}
+{{ toYaml .Values.reloader.rbac.labels | indent 4 }}
+{{- end }}
+{{- if .Values.reloader.matchLabels }}
+{{ toYaml .Values.reloader.matchLabels | indent 4 }}
+{{- end }}
+  name: {{ template "reloader-fullname" . }}-role-binding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "reloader-fullname" . }}-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "reloader-serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/stable/reloader/templates/service.yaml
+++ b/stable/reloader/templates/service.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.reloader.service }}
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.reloader.service.annotations }}
+  annotations:
+{{ toYaml .Values.reloader.service.annotations | indent 4 }}
+{{- end }}
+  labels:
+{{ include "reloader-labels.chart" . | indent 4 }}
+{{- if .Values.reloader.service.labels }}
+{{ toYaml .Values.reloader.service.labels | indent 4 }}
+{{- end }}
+  name: {{ template "reloader-fullname" . }}
+spec:
+  selector:
+{{- if .Values.reloader.deployment.labels }}
+{{ toYaml .Values.reloader.deployment.labels | indent 4 }}
+{{- end }}
+{{- if .Values.reloader.matchLabels }}
+{{ toYaml .Values.reloader.matchLabels | indent 4 }}
+{{- end }}
+  ports:
+{{ toYaml .Values.reloader.service.ports | indent 4 }}
+{{- end }}

--- a/stable/reloader/templates/serviceaccount.yaml
+++ b/stable/reloader/templates/serviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.reloader.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
+{{- end }}
+metadata:
+  labels:
+{{ include "reloader-labels.chart" . | indent 4 }}
+{{- if .Values.reloader.serviceAccount.labels }}
+{{ toYaml .Values.reloader.serviceAccount.labels | indent 4 }}
+{{- end }}
+{{- if .Values.reloader.matchLabels }}
+{{ toYaml .Values.reloader.matchLabels | indent 4 }}
+{{- end }}
+  name: {{ template "reloader-serviceAccountName" . }}
+{{- end }}

--- a/stable/reloader/values.yaml
+++ b/stable/reloader/values.yaml
@@ -44,10 +44,10 @@ reloader:
     labels:
       provider: stakater
       group: com.stakater.platform
-      version: v0.0.58
+      version: 0.0.58
     image:
-      name: stakater/reloader
-      tag: "v0.0.58"
+      name: registry.suse.com/caasp/v5/reloader
+      tag: "0.0.58"
       pullPolicy: IfNotPresent
     # Support for extra environment variables.
     env:

--- a/stable/reloader/values.yaml
+++ b/stable/reloader/values.yaml
@@ -1,0 +1,99 @@
+# Generated from deployments/kubernetes/templates/chart/values.yaml.tmpl
+global:
+  ## Reference to one or more secrets to be used when pulling images
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  imagePullSecrets: []
+
+kubernetes:
+  host: https://kubernetes.default
+
+reloader:
+  isOpenshift: false
+  ignoreSecrets: false
+  ignoreConfigMaps: false
+  logFormat: "" #json
+  watchGlobally: true
+  # Set to true if you have a pod security policy that enforces readOnlyRootFilesystem
+  readOnlyRootFileSystem: false
+  matchLabels: {}
+  deployment:
+    nodeSelector:
+    # cloud.google.com/gke-nodepool: default-pool
+
+    # An affinity stanza to be applied to the Deployment.
+    # Example:
+    #   affinity:
+    #     nodeAffinity:
+    #       requiredDuringSchedulingIgnoredDuringExecution:
+    #         nodeSelectorTerms:
+    #         - matchExpressions:
+    #           - key: "node-role.kubernetes.io/infra-worker"
+    #             operator: "Exists"
+    affinity: {}
+
+    # A list of tolerations to be applied to the Deployment.
+    # Example:
+    #   tolerations:
+    #   - key: "node-role.kubernetes.io/infra-worker"
+    #     operator: "Exists"
+    #     effect: "NoSchedule"
+    tolerations: []
+
+    annotations: {}
+    labels:
+      provider: stakater
+      group: com.stakater.platform
+      version: v0.0.58
+    image:
+      name: stakater/reloader
+      tag: "v0.0.58"
+      pullPolicy: IfNotPresent
+    # Support for extra environment variables.
+    env:
+      # Open supports Key value pair as environment variables.
+      open:
+      # secret supports Key value pair as environment variables. It gets the values based on keys from default reloader secret if any.
+      secret:
+      # field supports Key value pair as environment variables. It gets the values from other fields of pod.
+      field:
+
+    # Specify resource requests/limits for the deployment.
+    # Example:
+    # resources:
+    #   limits:
+    #     cpu: "100m"
+    #     memory: "512Mi"
+    #   requests:
+    #     cpu: "10m"
+    #     memory: "128Mi"
+    resources: {}
+    pod:
+      annotations: {}
+
+  service: {}
+    # labels: {}
+    # annotations: {}
+    # ports:
+    # - port: 9090
+    #   name: http
+    #   protocol: TCP
+    #   targetPort: 9090
+
+  rbac:
+    enabled: true
+    labels: {}
+  # Service account config for the agent pods
+  serviceAccount:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    labels: {}
+    # The name of the ServiceAccount to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: 
+  # Optional flags to pass to the Reloader entrypoint
+  # Example:
+  #   custom_annotations:
+  #     configmap: "my.company.com/configmap"
+  #     secret: "my.company.com/secret"
+  custom_annotations: {}


### PR DESCRIPTION
reloader is a Kubernetes controller to watch changes in ConfigMap and Secrets
and do rolling upgrades on Pods with their associated
Deployment, StatefulSet, DaemonSet and DeploymentConfig.

copy the reloader helm chart from
https://github.com/stakater/Reloader/tree/v0.0.58/deployments/kubernetes/chart/reloader

splits into multiple commits, the first commit is directly copied from the upstream helm chart, the rest commits are updated for SUSE.

xref https://github.com/SUSE/avant-garde/issues/1633

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>