### PR TITLE
Mount kubelet-client-current.pem

### DIFF
--- a/stable/cert-exporter/Chart.yaml
+++ b/stable/cert-exporter/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 2.3.0
 description: A Helm chart for cert-exporter
 name: cert-exporter
-version: 1.0.0
+version: 1.0.1

--- a/stable/cert-exporter/templates/node-certs-daemonset.yaml
+++ b/stable/cert-exporter/templates/node-certs-daemonset.yaml
@@ -37,6 +37,10 @@ spec:
           hostPath:
             path: /var/lib/kubelet/pki/kubelet.crt
             type: FileOrCreate
+        - name: kubelet-client-current
+          hostPath:
+            path: /var/lib/kubelet/pki/kubelet-client-current.pem
+            type: FileOrCreate
         - name: admin-conf
           hostPath:
             path: /etc/kubernetes/admin.conf
@@ -108,6 +112,7 @@ spec:
             - --include-cert-glob=/etc/kubernetes/pki/*.crt
             - --include-cert-glob=/etc/kubernetes/pki/etcd/*.crt
             - --include-cert-glob=/var/lib/kubelet/pki/*.crt
+            - --include-cert-glob=/var/lib/kubelet/pki/*.pem
             - --alsologtostderr
           env:
             - name: NODE_NAME
@@ -124,6 +129,9 @@ spec:
               readOnly: true
             - mountPath: /var/lib/kubelet/pki/kubelet.crt
               name: kubelet
+              readOnly: true
+            - mountPath: /var/lib/kubelet/pki/kubelet-client-current.pem
+              name: kubelet-client-current
               readOnly: true
             - mountPath: /etc/kubernetes/admin.conf
               name: admin-conf


### PR DESCRIPTION
xref https://github.com/SUSE/avant-garde/issues/1632

We need to monitor the `kubelet-server-current.pem`, we missed this part before.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>