### PR TITLE
Bump rsyslog container image in log-agent-rsyslog to v4.5

### DIFF
--- a/stable/log-agent-rsyslog/Chart.yaml
+++ b/stable/log-agent-rsyslog/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 8.39.0
 description: Log Agent for forwarding logs of K8s control plane, namespaces, operating system to Rsyslog
 name: log-agent-rsyslog
-version: 1.0.3
+version: 1.0.4

--- a/stable/log-agent-rsyslog/README.md
+++ b/stable/log-agent-rsyslog/README.md
@@ -1,6 +1,6 @@
 # Log-Agent-Rsyslog
 
-[Rsyslog](https://www.rsyslog.com/) is the rocket-fast system for log processing. You can use Log-Agent-Rsyslog to forward OS and Kubernetes cluster logs to centralized location such as Rsyslog server.
+[Rsyslog](https://www.rsyslog.com/) is the rocket-fast system for log processing. You can use Log-Agent-Rsyslog to forward OS and Kubernetes cluster logs to a centralized location such as Rsyslog server.
 
 ## Introduction
 
@@ -32,38 +32,38 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the log-agent-rsyslog chart and their default values.
 
-| Parameter | Description | Default |
-| - | - | - |
-| `image.repository` | The image repository to pull from | `registry.suse.com/caasp/v4.5/rsyslog` |
-| `image.tag` | The image tag to pull | `8.39.0` |
-| `server.host` | Rsyslog server host | `rsyslog-server.default.svc.cluster.local` |
-| `server.port` | Rsyslog server port | `514` |
-| `server.protocol` | Rsyslog server protocol | `tcp` |
-| `server.tls.enabled` | Enable TLS | `false` |
-| `server.tls.rootCa` | TLS rootCA |  |
-| `server.tls.permittedPeer` | TLS server permitted peer | |
-| `server.tls.clientCert` | TLS client cert | |
-| `server.tls.clientKey` | TLS client key | |
-| `resources.limits.cpu` | CPU limits | |
-| `resources.limits.memory` | Memory limits | `512Mi` |
-| `resources.requests.cpu` | CPU requests | `100m` |
-| `resources.requests.memory` | Memory requests | `512Mi` |
-| `persistStateInterval` | Rsyslog persist state interval in second | `100` |
-| `resumeInverval` | Rsyslog resume interval in second | `30` |
-| `resumeRetryCount` | Rsyslog resume retry count. `-1` is unlimited | `-1` |
-| `queue.enabled` | Enable Rsyslog queue | `false` |
-| `queue.size` | Rsyslog queue size in byte | `100000` |
-| `queue.maxDiskSpace` | Rsyslog queue max disk space in byte | `2147483648` |
-| `kubernetesPodLabelsEnabled` | Enable kubernetes meta labels in pod logs | `false` |
-| `kubernetesPodAnnotationsEnabled` | Enable kubernetes meta annotations in pod logs | `false` |
-| `logs.osSystem.enabled` | Enable forwarding os system logs (auditd, kernel, wicked*, zypper) | `true` |
-| `logs.kubernetesSystem.enabled` | Enable forwarding kubernetes system logs (kubelet, crio) | `true` |
-| `logs.kubernetesControlPlane.enabled` | Enable forwarding kubernetes control plane logs | `true` |
-| `logs.kubernetesUserNamespaces.enabled` | Enable forwarding kubernetes user namespaces logs | `false` |
-| `logs.kubernetesUserNamespaces.exclude` | Exclude forwarding kubernetes logs for specific namespaces | `- ""` |
-| `logs.kubernetesAudit.enabled` | Enables forwarding kubernetes audit logs | `true` |
-| `logs.kubernetesAudit.logDir` | Kubernetes audit log directory | `/var/log/kube-apiserver` |
-| `logs.kubernetesAudit.logFile` | Kubernetes audit log filename | `audit.log` |
+| Parameter                               | Description                                                        | Default                                    |
+| -                                       | -                                                                  | -                                          |
+| `image.repository`                      | The image repository to pull from                                  | `registry.suse.com/caasp/v4.5/rsyslog`     |
+| `image.tag`                             | The image tag to pull                                              | `8.39.0`                                   |
+| `server.host`                           | Rsyslog server host                                                | `rsyslog-server.default.svc.cluster.local` |
+| `server.port`                           | Rsyslog server port                                                | `514`                                      |
+| `server.protocol`                       | Rsyslog server protocol                                            | `tcp`                                      |
+| `server.tls.enabled`                    | Enable TLS                                                         | `false`                                    |
+| `server.tls.rootCa`                     | TLS rootCA                                                         |                                            |
+| `server.tls.permittedPeer`              | TLS server permitted peer                                          |                                            |
+| `server.tls.clientCert`                 | TLS client cert                                                    |                                            |
+| `server.tls.clientKey`                  | TLS client key                                                     |                                            |
+| `resources.limits.cpu`                  | CPU limits                                                         |                                            |
+| `resources.limits.memory`               | Memory limits                                                      | `512Mi`                                    |
+| `resources.requests.cpu`                | CPU requests                                                       | `100m`                                     |
+| `resources.requests.memory`             | Memory requests                                                    | `512Mi`                                    |
+| `persistStateInterval`                  | Rsyslog persist state interval in second                           | `100`                                      |
+| `resumeInverval`                        | Rsyslog resume interval in second                                  | `30`                                       |
+| `resumeRetryCount`                      | Rsyslog resume retry count. `-1` is unlimited                      | `-1`                                       |
+| `queue.enabled`                         | Enable Rsyslog queue                                               | `false`                                    |
+| `queue.size`                            | Rsyslog queue size in byte                                         | `100000`                                   |
+| `queue.maxDiskSpace`                    | Rsyslog queue max disk space in byte                               | `2147483648`                               |
+| `kubernetesPodLabelsEnabled`            | Enable kubernetes meta labels in pod logs                          | `false`                                    |
+| `kubernetesPodAnnotationsEnabled`       | Enable kubernetes meta annotations in pod logs                     | `false`                                    |
+| `logs.osSystem.enabled`                 | Enable forwarding os system logs (auditd, kernel, wicked*, zypper) | `true`                                     |
+| `logs.kubernetesSystem.enabled`         | Enable forwarding kubernetes system logs (kubelet, crio)           | `true`                                     |
+| `logs.kubernetesControlPlane.enabled`   | Enable forwarding kubernetes control plane logs                    | `true`                                     |
+| `logs.kubernetesUserNamespaces.enabled` | Enable forwarding kubernetes user namespaces logs                  | `false`                                    |
+| `logs.kubernetesUserNamespaces.exclude` | Exclude forwarding kubernetes logs for specific namespaces         | `- ""`                                     |
+| `logs.kubernetesAudit.enabled`          | Enables forwarding kubernetes audit logs                           | `true`                                     |
+| `logs.kubernetesAudit.logDir`           | Kubernetes audit log directory                                     | `/var/log/kube-apiserver`                  |
+| `logs.kubernetesAudit.logFile`          | Kubernetes audit log filename                                      | `audit.log`                                |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/log-agent-rsyslog/README.md
+++ b/stable/log-agent-rsyslog/README.md
@@ -34,7 +34,7 @@ The following table lists the configurable parameters of the log-agent-rsyslog c
 
 | Parameter | Description | Default |
 | - | - | - |
-| `image.repository` | The image repository to pull from | `registry.suse.com/caasp/v4/rsyslog` |
+| `image.repository` | The image repository to pull from | `registry.suse.com/caasp/v4.5/rsyslog` |
 | `image.tag` | The image tag to pull | `8.39.0` |
 | `server.host` | Rsyslog server host | `rsyslog-server.default.svc.cluster.local` |
 | `server.port` | Rsyslog server port | `514` |

--- a/stable/log-agent-rsyslog/ci/mtls-verify-peer-values.yaml
+++ b/stable/log-agent-rsyslog/ci/mtls-verify-peer-values.yaml
@@ -1,6 +1,6 @@
 ---
 image:
-  repository: registry.suse.com/caasp/v4/rsyslog
+  repository: registry.suse.com/caasp/v4.5/rsyslog
   tag: 8.39.0
 
 server:

--- a/stable/log-agent-rsyslog/ci/mtls-verify-rootca-values.yaml
+++ b/stable/log-agent-rsyslog/ci/mtls-verify-rootca-values.yaml
@@ -1,6 +1,6 @@
 ---
 image:
-  repository: registry.suse.com/caasp/v4/rsyslog
+  repository: registry.suse.com/caasp/v4.5/rsyslog
   tag: 8.39.0
 
 server:

--- a/stable/log-agent-rsyslog/ci/tls-values.yaml
+++ b/stable/log-agent-rsyslog/ci/tls-values.yaml
@@ -1,6 +1,6 @@
 ---
 image:
-  repository: registry.suse.com/caasp/v4/rsyslog
+  repository: registry.suse.com/caasp/v4.5/rsyslog
   tag: 8.39.0
 
 server:

--- a/stable/log-agent-rsyslog/ci/values.yaml
+++ b/stable/log-agent-rsyslog/ci/values.yaml
@@ -1,6 +1,6 @@
 ---
 image:
-  repository: registry.suse.com/caasp/v4/rsyslog
+  repository: registry.suse.com/caasp/v4.5/rsyslog
   tag: 8.39.0
 
 server:

--- a/stable/log-agent-rsyslog/tests/helpers/rsyslog-server/rsyslog-server-deployment.yaml
+++ b/stable/log-agent-rsyslog/tests/helpers/rsyslog-server/rsyslog-server-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: rsyslog-server
-        image: registry.suse.com/caasp/v4/rsyslog:8.39.0
+        image: registry.suse.com/caasp/v4.5/rsyslog:8.39.0
         imagePullPolicy: "Always"
         command: ["rsyslogd"]
         args: ["-n", "-f", "/etc/rsyslog.conf"]

--- a/stable/log-agent-rsyslog/values.yaml
+++ b/stable/log-agent-rsyslog/values.yaml
@@ -1,6 +1,6 @@
 ---
 image:
-  repository: registry.suse.com/caasp/v4/rsyslog
+  repository: registry.suse.com/caasp/v4.5/rsyslog
   tag: 8.39.0
 
 server:


### PR DESCRIPTION
Updates log-agent-rsyslog to v4.5 repo. 

Verified deployment and log forwarding with the default setting.

Ref: https://github.com/SUSE/avant-garde/issues/1912