### PR TITLE
Add `system_domain: example.com` for CAP charts

### DIFF
--- a/.ci/scf-config-values.yaml
+++ b/.ci/scf-config-values.yaml
@@ -1,3 +1,4 @@
+system_domain: example.com
 CF_ADMIN_USER: test
 env:
   CF_DOMAIN: test


### PR DESCRIPTION
CAP charts require `system_domain` on values.yaml.

That is intentional. You must provide a system_domain to render the chart.
The check exists to make sure users don't forget.

If you helm lint the chart, you must provide a value as well; it doesn't matter
what you use.