### PR TITLE
changed support URL to suse.com

### DIFF
--- a/stable/kubecf/config/api.yaml
+++ b/stable/kubecf/config/api.yaml
@@ -3,8 +3,8 @@ properties:
     cloud_controller_ng:
       name: KubeCF
       version: 2
-      description: 'CloudFoundry KubeCF'
-      support_address: 'https://kubecf.io/'
+      description: 'SUSE version of CloudFoundry KubeCF'
+      support_address: 'https://www.suse.com/support/'
       build: {{ default .Chart.Version .Chart.AppVersion | quote }}
 
 # Note that the version information has to be a plain integer, as per the


### PR DESCRIPTION
Need to look up API syntax for documentation link: https://documentation.suse.com/en-us/suse-cap