### PR TITLE
Stratos Helm Chart: Fix broken tlsSecretName

### DIFF
--- a/stable/console/templates/deployment.yaml
+++ b/stable/console/templates/deployment.yaml
@@ -345,7 +345,7 @@ spec:
       - name: "{{ .Release.Name }}-cert-volume"
         secret:
           {{- if .Values.console.tlsSecretName }}
-          secretName: "{{ .values.console.tlsSecretName }}"
+          secretName: "{{ .Values.console.tlsSecretName }}"
           {{- else }}
           secretName: "{{ .Release.Name }}-cert"
           {{- end }}


### PR DESCRIPTION
Should be .Values not .values